### PR TITLE
[HOTFIX] Stop user verify from triggering twice

### DIFF
--- a/frontend/src/components/UserManage.js
+++ b/frontend/src/components/UserManage.js
@@ -15,7 +15,7 @@ Modal.setAppElement(document.getElementById("root"));
 function VerifyButtonCell({
   isVerified: initialVerified,
   name: userName,
-  row: { index },
+  row: { index, original },
   column: { id },
   updateMyData,
   handleConfirmationModal,
@@ -27,8 +27,7 @@ function VerifyButtonCell({
   }, [initialVerified]);
 
   function handleVerifyUser() {
-    // console.log({ index, id });
-    updateMyData(index, id, true);
+    updateMyData(index, id, true, original._id);
     setIsVerifiedState(true);
   }
 
@@ -120,23 +119,23 @@ export default function UserManage() {
     fetchUsers();
   }, []);
 
-  const updateMyData = (rowIndex, columnId, value) => {
+  const updateMyData = (_rowIndex, columnId, value, userId) => {
     // We also turn on the flag to not reset the page
-    setUserData((old) =>
-      old.map((row, index) => {
-        if (index === rowIndex) {
-          // verify user here, reload if fail
-          api_user_verify(row._id).then((res) => {
-            if (!res || res.error) navigate(window.location);
-          });
-          return {
-            ...old[rowIndex],
-            [columnId]: value,
-          };
-        }
-        return row;
-      })
-    );
+    // we don't use rowIndex because we filter before displaying, so the userData
+    // includes users from both the admin and user lists
+    api_user_verify(userId).then((res) => {
+      if (!res || res.error) navigate(window.location);
+
+      const old = [...userData] ?? [];
+      const i = old.findIndex((row) => row._id === userId);
+
+      const newData = old.splice(i, 1, {
+        ...old[i],
+        [columnId]: value,
+      });
+
+      setUserData(old);
+    });
   };
 
   const handleConfirmationModal = ({ name, isOpen }) => {
@@ -180,7 +179,8 @@ export default function UserManage() {
         overlayClassName="access_notification_overlay"
       >
         <div className="notification_contents">
-          {modalState.name ?? "User"} has been given access.
+          {modalState.name ?? "User"} has been given access and will be sent a notification via
+          email.
           <button
             type="button"
             className="confirmation_btn"

--- a/frontend/src/components/UserManage.js
+++ b/frontend/src/components/UserManage.js
@@ -129,7 +129,7 @@ export default function UserManage() {
       const old = [...userData] ?? [];
       const i = old.findIndex((row) => row._id === userId);
 
-      const newData = old.splice(i, 1, {
+      old.splice(i, 1, {
         ...old[i],
         [columnId]: value,
       });


### PR DESCRIPTION
### Administrative Info
M/A

### Changes
What changes did you make?
- fixed updateMyData function to correctly modify the user data and only trigger API once

### Testing
How did you confirm your changes worked? 
- tested locally

### Confirmation of Change 

