### PR TITLE
[Hotfix] Hide deactivated accounts from assign modal

### DIFF
--- a/frontend/src/components/AssignModal.js
+++ b/frontend/src/components/AssignModal.js
@@ -29,6 +29,7 @@ export default function AssignModal({ name, isOpen, setOpen, volunteers, setVolu
       users.filter(
         (user) =>
           user.name &&
+          user.active &&
           (user.name.toLowerCase().includes(e?.target?.value ?? search) ||
             user.email.toLowerCase().includes(e?.target?.value ?? search)) &&
           (roles.length === ROLES.length ||
@@ -40,8 +41,9 @@ export default function AssignModal({ name, isOpen, setOpen, volunteers, setVolu
   useEffect(async () => {
     const res = await api_user_all();
     if (res?.users) {
-      setUsers(res.users);
-      setFilteredUsers(res.users);
+      const active_users = res.users.filter((user) => user.active);
+      setUsers(active_users);
+      setFilteredUsers(active_users);
     }
 
     function resize() {


### PR DESCRIPTION
### Administrative Info
[GitHub Issue N/A]

### Changes
What changes did you make?
- Changed `AssignModal.js` to exclude deactivated accounts

### Testing
How did you confirm your changes worked? 
- Manual testing

### Confirmation of Change 

No visible change, other than deactivated accounts no longer being visible in the assign modal.